### PR TITLE
Fix regex bug

### DIFF
--- a/src/components/BadPasswordRules/BadPasswordRules.tsx
+++ b/src/components/BadPasswordRules/BadPasswordRules.tsx
@@ -18,21 +18,26 @@ const runValidations = (password: string, validations: Validations) =>
   }));
 
 const generateSeed = () => {
+  let seed = Math.round(Math.random() * 9999);
+
   // if address has ?seed=, use that value
   const params = new URLSearchParams(window.location.search);
   if (params.has('seed')) {
     const seedStr = params.get('seed') ?? '';
-    const seed = parseInt(seedStr, 10);
-    if (!Number.isNaN(seed)) {
-      return seed;
+    const seedInt = parseInt(seedStr, 10);
+    if (!Number.isNaN(seedInt)) {
+      seed = seedInt;
     }
   }
 
-  return Math.round(Math.random() * 9999);
+  console.debug(`Using seed ${seed}`);
+
+  return seed;
 };
 
+const initSeed = generateSeed();
 const BadPasswordRules = ({ api }: { api: BadPasswordRulesRef }) => {
-  const [seed, setSeed] = useState(generateSeed());
+  const [seed, setSeed] = useState(initSeed);
   const [password, setPassword] = useState('');
 
   const [validationIds, setValidationIds] = useState<Array<string>>([]);

--- a/src/components/BadPasswordRules/BadPasswordRules.tsx
+++ b/src/components/BadPasswordRules/BadPasswordRules.tsx
@@ -17,7 +17,19 @@ const runValidations = (password: string, validations: Validations) =>
     inputValue: password,
   }));
 
-const generateSeed = () => Math.round(Math.random() * 9999);
+const generateSeed = () => {
+  // if address has ?seed=, use that value
+  const params = new URLSearchParams(window.location.search);
+  if (params.has('seed')) {
+    const seedStr = params.get('seed') ?? '';
+    const seed = parseInt(seedStr, 10);
+    if (!Number.isNaN(seed)) {
+      return seed;
+    }
+  }
+
+  return Math.round(Math.random() * 9999);
+};
 
 const BadPasswordRules = ({ api }: { api: BadPasswordRulesRef }) => {
   const [seed, setSeed] = useState(generateSeed());

--- a/src/helpers/validations.ts
+++ b/src/helpers/validations.ts
@@ -10,10 +10,35 @@ import {
   SPECIAL_CHARACTER,
 } from './characters';
 
+function* obscureUnicodeCharsGenerator() {
+  while (true) {
+    // these characters are obscure enough that we don't expect users to enter them
+    yield '\u200B'; // zero-width space
+    yield '\u200C'; // zero-width non-joiner
+  }
+}
+
 const removeCensoredSwearWords = (s: string) =>
   censoredSwearWords.reduce((acc, w) => {
     const globalRegexOfWord = RegExp(w.replace(/\*/g, '\\*'), 'gi');
-    return acc.replace(globalRegexOfWord, '');
+
+    // NOTE: here, we replace with obscure unicode characters instead of
+    // empty strings. Without this, we'd be bringing together the characters
+    // before and after the substring, which could cause other validations to
+    // fail.
+    //
+    // For example: '1f**k1' would become '11', which would violate the
+    // repeatedCharacters2 validation. Instead, it becomes '1<character>1`
+    //
+    // We use obscure unicode chars so that we don't accidentally insert a
+    // character that might match one of the two neighboring characters.
+    //
+    // Furthermore, we replace with alternating unicode characters so that
+    // '1f**kf**k1' becomes `1<charA><charB>1`.
+    const replacerChars = obscureUnicodeCharsGenerator();
+    const replacer = () => replacerChars.next().value as string;
+
+    return acc.replace(globalRegexOfWord, replacer);
   }, s);
 
 const getMaxLength = (seed: number) => 16 + (seed % 4);


### PR DESCRIPTION
The issue is that when the `removeCensoredSwearWords` function removes something like "c**p", it causes the character before that substring and the character after that substring to be adjacent. If those characters are the same, the "no two of the same character in a row" validation will now incorrectly fail.

This PR fixes the issue by replacing the removed words with obscure unicode characters instead of empty strings. This isn't the most robust solution, but it's the quickest to implement for me.

This PR also adds the ability to specify the seed via query params and debug logging for the seed.
